### PR TITLE
don't need authentication to access to ouvrage by name

### DIFF
--- a/interface/spo/views.py
+++ b/interface/spo/views.py
@@ -135,7 +135,6 @@ def publication_generation_ended(request, generation_id):
     return _forward_http_file(response)
 
 
-@login_required
 @require_GET
 def ouvrages_by_name(request):
     ouvrages_from_generator = generator.get(


### PR DESCRIPTION
As SPPNautSPO is now accessible only inside Shom we should remove the authentication on `ouvrage by name` paeg to allow all Shom employee to access to this page